### PR TITLE
[#109073500] Automated test for Docker builds

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - docker build -t terraform .
+  - docker run -d terraform bash -c "terraform version"
+  - docker ps -a
+
+script:
+  - bundle exec rake

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.6.7
+ENV TERRAFORM_VER 0.6.8
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
 RUN apt-get update && apt-get -y install wget unzip openssh-client ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+source 'https://rubygems.org'
+
+gem 'docker-api', '~> 1.21'
+gem 'serverspec', '~> 2.19'
+
+# You should_not start your specs with the string "should"
+gem 'should_not', '~> 1.1'
+
+gem 'rake', '~> 10.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,55 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    docker-api (1.23.0)
+      excon (>= 0.38.0)
+      json
+    excon (0.45.4)
+    json (1.8.1)
+    multi_json (1.11.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-telnet (0.1.1)
+    rake (10.4.2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    serverspec (2.24.3)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.43)
+    sfl (2.2)
+    should_not (1.1.0)
+    specinfra (2.44.3)
+      net-scp
+      net-ssh (~> 2.7)
+      net-telnet
+      sfl
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docker-api (~> 1.21)
+  rake (~> 10.4.2)
+  serverspec (~> 2.19)
+  should_not (~> 1.1)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/alphagov/paas-docker-terraform.svg)](https://travis-ci.org/alphagov/paas-docker-terraform)
 # docker-terraform
 
 This container allows to run Terraform ( 0.6.7 ) inside docker container. You need to export your credencials as envirnoment variables. For AWS it needs ```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new()
+
+task :default => :spec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'serverspec'
+require 'docker'
+
+    set :os, family: :debian
+    set :backend, :docker
+

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "Terraform image" do
+before(:all) do
+    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'terraform:latest' }
+    set :docker_image, @image.id
+end
+    
+    it "should be availble" do
+        expect(@image).to_not be_nil
+    end
+
+    it "installs the right version of Ubuntu" do
+        expect(os_version).to include("Ubuntu 14")
+    end
+
+    def os_version
+        command("lsb_release -a").stdout
+    end
+
+    it "installs openssh-client" do
+        expect(package("openssh-client")).to be_installed
+    end
+
+    it "checks if terraform binary is executable" do
+         expect(file("/usr/local/bin/terraform")).to be_mode 775
+    end
+
+    it "has the Terraform version 0.6.8" do
+        expect(terraform_version).to include("Terraform v0.6.8")
+    end
+
+    def terraform_version
+        command("terraform version").stdout.strip
+    end
+end


### PR DESCRIPTION
# What

This adds automated tests of Docker container that are executed by Travis CI for every commit and PR.
# Details

It is using rspec/serverspec to define tests and execute them with `rake`.

Currently we are checking whether image:
- is available
- installs the right version of Ubuntu
- installs openssh-client
- checks if terraform binary is executable
- has the Terraform version 0.6.7
# How to test this
### locally
- `docker build -t terraform .`
- `bundle install`
- `rake`
### travis
- fork repo
- create PR
- check for build result
# Who can test

Anyone but @combor and @saliceti 
