### PR TITLE
[#109540406] Update TF container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 before_install:
   - docker build -t terraform .
-  - docker run -d terraform bash -c "terraform version"
+  - docker run -d terraform sh -c "terraform version"
   - docker ps -a
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 
 before_install:
-  - docker build -t terraform .
-  - docker run -d terraform sh -c "terraform version"
+  - docker build -t governmentpaas/docker-terraform .
+  - docker run -d governmentpaas/docker-terraform sh -c "terraform version"
   - docker ps -a
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM ubuntu:latest
+FROM alpine
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.6.8
+ENV TERRAFORM_VER 0.6.8_fixed
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
-RUN apt-get update && apt-get -y install wget unzip openssh-client ruby
+RUN apk update && apk add openssl openssh    
 RUN set -ex \
-       && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/terraform_${TERRAFORM_ZIP} \
-       && unzip /tmp/terraform_${TERRAFORM_ZIP} -d /usr/local/bin \
-       && chmod 775 /usr/local/bin/terra* \
-       && rm /tmp/terraform_${TERRAFORM_ZIP}
+       && wget https://github.com/alphagov/terraform/releases/download/v${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
+       && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin \
+       && rm /tmp/${TERRAFORM_ZIP}
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/alphagov/paas-docker-terraform.svg)](https://travis-ci.org/alphagov/paas-docker-terraform)
 # docker-terraform
 
-This container allows to run Terraform ( 0.6.7 ) inside docker container. You need to export your credencials as envirnoment variables. For AWS it needs ```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```
+This container allows to run Terraform ( 0.6.9-dev ) inside docker container. You need to export your credencials as envirnoment variables. For AWS it needs ```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```
 
 ## How to run and build
 

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -10,27 +10,27 @@ end
         expect(@image).to_not be_nil
     end
 
-    it "installs the right version of Ubuntu" do
-        expect(os_version).to include("Ubuntu 14")
-    end
-
-    def os_version
-        command("lsb_release -a").stdout
-    end
-
-    it "installs openssh-client" do
-        expect(package("openssh-client")).to be_installed
+    it "installs the Alpine linux" do
+         expect(file("/etc/alpine-release")).to be_file
     end
 
     it "checks if terraform binary is executable" do
-         expect(file("/usr/local/bin/terraform")).to be_mode 775
+         expect(file("/usr/local/bin/terraform")).to be_mode 755
     end
 
-    it "has the Terraform version 0.6.8" do
-        expect(terraform_version).to include("Terraform v0.6.8")
+    it "has the Terraform version 0.6.9" do
+        expect(terraform_version).to include("Terraform v0.6.9")
     end
 
     def terraform_version
         command("terraform version").stdout.strip
+    end
+
+    it "installs SSH" do
+        expect(ssh_version).to include("OpenSSH")
+    end
+
+    def ssh_version
+        command("ssh -V").stderr.strip
     end
 end

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Terraform image" do
 before(:all) do
-    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'terraform:latest' }
+    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'governmentpaas/docker-terraform:latest' }
     set :docker_image, @image.id
 end
     


### PR DESCRIPTION
# What

The goal of this PR is to update Terraform version to include fix for forced destroy of S3 bucked and  to reduce the container size.
# Details

We have achieved both by:
- compiling patched version of TF and creating new release on https://github.com/alphagov/terraform
- replacing Ubuntu with Alpine Linux which reduced OS layer size from 200MB to 6MB
- compressing TF binaries with [goupx](https://github.com/pwaller/goupx) + [upx](http://upx.sourceforge.net/)
- removing unused TF providers

Those changes allowed to reduce the size of the container from 700MB to ~50MB which is ~7% of original.
# How to test
- `docker build -t governmentpaas/docker-terraform .`
- `gem install bundle`
- `bundle install`
- `rake`
# Who can test

Anyone but @mtekel and @combor
