### PR TITLE
Terraform requires certificates to operate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV PATH $PATH:/usr/local/bin
 ENV TERRAFORM_VER 0.6.8_fixed
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
-RUN apk update && apk add openssl openssh    
+RUN apk update && apk add openssl openssh ca-certificates
 RUN set -ex \
        && wget https://github.com/alphagov/terraform/releases/download/v${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
        && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin \

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -14,6 +14,10 @@ end
          expect(file("/etc/alpine-release")).to be_file
     end
 
+    it "installs Root Certificates" do
+         expect(file("/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA.crt")).to be_file
+    end
+
     it "checks if terraform binary is executable" do
          expect(file("/usr/local/bin/terraform")).to be_mode 755
     end


### PR DESCRIPTION
# What

While working on Concourse pipeline we have discovered that Terraform requires CA certificates to run. This PR adds them and modifies tests to check whether they are available.
# How to test
- `docker build -t governmentpaas/docker-terraform .` 
- `docker run -ti -e TF_VAR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID governmentpaas/docker-terraform sh`
- `export AWS_DEFAULT_REGION=eu-west-1`
- `terraform remote config -backend=s3 -backend-config=bucket=colin-new-state -backend-config="key=vpc.tfstate"`
# Who can test

Anyone but @combor
