### PR TITLE
Terraform version bump to 0.6.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.6.8_fixed
+ENV TERRAFORM_VER 0.6.9
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
 RUN apk update && apk add openssl openssh ca-certificates
 RUN set -ex \
-       && wget https://github.com/alphagov/terraform/releases/download/v${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
+       && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
        && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin \
        && rm /tmp/${TERRAFORM_ZIP}
 


### PR DESCRIPTION
# What

To be able to use aws_nat_gateway resource which is required for [Implement NAT](https://www.pivotaltracker.com/story/show/111590274) story we need to bump Terraform version to 0.6.9 which includes this functionality.

https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md
# How to review

Build terraform container loccaly and check what is the terraform version

```
docker build -t combor/docker-terraform .
docker run -ti combor/docker-terraform terraform version
Terraform v0.6.9
```
# Who can review

Anyone but @combor
