### PR TITLE
[#109869960] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ This container allows you to run Terraform inside a Docker container.
 ## How to run it
 
 ```
-docker run -ti terraform
+docker run -ti terraform terraform
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/alphagov/paas-docker-terraform.svg)](https://travis-ci.org/alphagov/paas-docker-terraform)
 # docker-terraform
 
-This container allows to run Terraform ( 0.6.9-dev ) inside docker container. You need to export your credencials as envirnoment variables. For AWS it needs ```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```
+This container allows to run Terraform inside docker container. You need to export your credencials as envirnoment variables. For AWS it needs ```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```
 
 ## How to run and build
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![Build Status](https://travis-ci.org/alphagov/paas-docker-terraform.svg)](https://travis-ci.org/alphagov/paas-docker-terraform)
 # docker-terraform
 
-This container allows to run Terraform inside docker container. You need to export your credencials as envirnoment variables. For AWS it needs ```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```
+This container allows you to run Terraform inside a Docker container. You
+need to export your credentials as environment variables. For AWS it needs
+```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```
 
 ## How to run and build
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 [![Build Status](https://travis-ci.org/alphagov/paas-docker-terraform.svg)](https://travis-ci.org/alphagov/paas-docker-terraform)
 # docker-terraform
 
-This container allows you to run Terraform inside a Docker container. You
-need to export your credentials as environment variables. For AWS it needs
-```TF_VAR_AWS_ACCESS_KEY_ID``` and ```TF_VAR_AWS_SECRET_ACCESS_KEY```
+This container allows you to run Terraform inside a Docker container.
 
 ## How to run and build
 
@@ -12,8 +10,5 @@ need to export your credentials as environment variables. For AWS it needs
 ## How to run it
 
 ```
-docker run -ti \
-        -e TF_VAR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-        -e TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-        terraform
+docker run -ti terraform
 ```


### PR DESCRIPTION
### What

The version that we're using is no longer suffixed by `-dev` as it was when
we were building straight from hashicorp/terraform:master. Remove the
version from the README altogether, because there's a good chance that it
will be incorrect again in the future.

Fix some typos ("credentials" and "environment"), some grammar ("allow you
to" and "a Docker container"), and line wrap.
### How to test

Look at the README and see if it makes sense.
### Who can review

Not @dcarley
