### PR TITLE
[#112610295] Bump terraform version to 0.6.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.6.9
+ENV TERRAFORM_VER 0.6.10
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
 RUN apk update && apk add openssl openssh ca-certificates

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -22,8 +22,8 @@ end
          expect(file("/usr/local/bin/terraform")).to be_mode 755
     end
 
-    it "has the Terraform version 0.6.9" do
-        expect(terraform_version).to include("Terraform v0.6.9")
+    it "has the Terraform version 0.6.10" do
+        expect(terraform_version).to include("Terraform v0.6.10")
     end
 
     def terraform_version


### PR DESCRIPTION
This includes a fix for the `DuplicateListener` problem describe in
hashicorp/terraform#4880 and worked around in alphagov/paas-cf@f46ff52

Colin has confirmed that this now works without the `sleep 10`.

I don't believe we are affected by any of the backwards incompatibility
items listed in the CHANGELOG:
- https://github.com/hashicorp/terraform/blob/v0.6.10/CHANGELOG.md#0610-january-27-2016
