### PR TITLE
Revert "Container name change to math our offcial one"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 
 before_install:
-  - docker build -t governmentpaas/docker-terraform .
-  - docker run -d governmentpaas/docker-terraform sh -c "terraform version"
+  - docker build -t terraform .
+  - docker run -d terraform sh -c "terraform version"
   - docker ps -a
 
 script:

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Terraform image" do
 before(:all) do
-    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'governmentpaas/docker-terraform:latest' }
+    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'terraform:latest' }
     set :docker_image, @image.id
 end
     


### PR DESCRIPTION
This reverts commit 72bb2e4d575c65a23540b03b0893ed481ec0722d.

@mtekel noted in #10 that the instructions in the README for building
currently conflict with being able to run the tests locally.

I think we should use a temporary name, which doesn't match the Docker Hub
repo name, when building the container locally and in Travis for testing.
This reduces the chance of confusing it with the "real" container that
you've pulled from the public registry.

It also matches the behaviour of the containers in:
- alphagov/paas-docker-cloudfoundry-tools
