### PR TITLE
[#112665419] Reduce container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,18 @@ FROM alpine
 ENV PATH $PATH:/usr/local/bin
 ENV TERRAFORM_VER 0.6.10
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
+ENV BINARY_WHITELIST \
+  terraform \
+  terraform-provider-aws \
+  terraform-provider-null \
+  terraform-provider-template \
+  terraform-provider-tls \
+  terraform-provisioner-file \
+  terraform-provisioner-local-exec \
+  terraform-provisioner-remote-exec
 
 RUN apk update && apk add openssl openssh ca-certificates
 RUN set -ex \
        && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
-       && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin \
+       && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin ${BINARY_WHITELIST} \
        && rm /tmp/${TERRAFORM_ZIP}
-

--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ This container allows you to run Terraform inside a Docker container.
 ```
 docker run -ti terraform terraform
 ```
+
+## Container size and binary whitelist
+
+The Terraform installation is quite large; 30~ provider and provisioner
+binaries at 10~20M each. In order to reduce the size of the final container
+we only install the providers and provisioners that we expect to use. A list
+of these is maintained in the [Dockerfile](Dockerfile). We don't expect to
+need to do this in the future if [hashicorp/terraform#4233][] is solved.
+
+[hashicorp/terraform#4233]: https://github.com/hashicorp/terraform/issues/4233

--- a/spec/terraform_spec.rb
+++ b/spec/terraform_spec.rb
@@ -37,4 +37,12 @@ end
     def ssh_version
         command("ssh -V").stderr.strip
     end
+
+    it "should not have binary directory larger than 200M" do
+        expect(binaries_size).to be < 200
+    end
+
+    def binaries_size
+        Integer(command("du -m /usr/local/bin").stdout.split.first)
+    end
 end


### PR DESCRIPTION
## What

The Terraform installation is quite large; 30~ provider and provisioner
binaries at 10~20M each. In order to reduce the size of the final container
we only install the providers and provisioners that we expect to use. A list
of these is maintained in the [Dockerfile](Dockerfile). We don't expect to
need to do this in the future if hashicorp/terraform#4233 is solved.

I've picked all of the non-provider specific binaries with the exception of
AWS which we currently deploy alphagov/paas-cf to.

I did look at using upx, as described in the upstream issue. However it's
not easy to make use of it in our current build process. We'd have to
include Go to build goupx and besides Alpine Linux doesn't have a upx
package to build against. So we'd have to create/use a larger container just
to use it.

This brings down the size of the container from 590M to 160M:

```
➜  ~  docker images | grep terraform
terraform                         latest              7441268d0c1c        About an hour ago   162.1 MB
governmentpaas/docker-terraform   latest              f8a6bada0c7a        3 hours ago         590.8 MB
```

As seen from within the container:

```
➜  ~  docker run -ti --rm terraform du -h /usr/local/bin
144.9M  /usr/local/bin
➜  ~  docker run -ti --rm governmentpaas/docker-terraform du -h /usr/local/bin
553.8M  /usr/local/bin
```
## Notes

I'm a bit sceptical about how effective this actually is. If the consensus is that it's not much of an improvement for the additional complexity then I'm happy for us to bin the PR and story.

I tested it on a new Bootstrap Concourse machine which didn't have the containers previously cached. I used the following pipeline, with the jobs run manually, one after another, and observed the "duration" which includes the time taken to pull the container.

``` yaml

---
jobs:

- name: terraform-before
  public: true
  plan:
  - task: terraform-before
    config:
      platform: linux
      image: docker:///governmentpaas/docker-terraform
      run:
        path: du
        args: [/usr/local/bin]

- name: terraform-after
  public: true
  plan:
  - task: terraform-after
    config:
      platform: linux
      image: docker:///governmentpaas/docker-terraform#112665419-reduce_container_size
      run:
        path: du
        args: [/usr/local/bin]
```

The results were:
- `terraform-before`: 22~26 seconds
- `terraform-after`: 9~11 seconds

I'm also sceptical about how useful the additional test is and wouldn't object to omitting it.
## How to test

Modify your paas-cf pipelines to use the container built from this branch:

```
gsed -ri 's/(docker-terraform)/\1#112665419-reduce_container_size/' concourse/pipelines/*
```

Then re-run all of the pipelines and ensure that Terraform works correctly.
## Who can review

Not @dcarley
